### PR TITLE
#26704 - Add parameter for strict null comparison

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -22,7 +22,6 @@ enabled:
   - no_empty_phpdoc # There should not be empty PHPDoc blocks
   - no_extra_consecutive_blank_lines # Removes extra consecutive empty lines
   - no_short_bool_cast # Short cast bool using double exclamation mark should not be used
-  - no_unreachable_default_argument_value # In method arguments there must not be arguments with default values before non-default ones
   - no_unused_imports # Unused use statements must be removed
   - no_useless_else # There should not be useless else cases
   - no_useless_return # There should not be an empty return statement at the end of a function

--- a/NetiPhpExcel.php
+++ b/NetiPhpExcel.php
@@ -1,7 +1,9 @@
 <?php
 /**
  * @copyright  Copyright (c) 2016, Net Inventors GmbH
+ *
  * @category   Shopware
+ *
  * @author     hrombach
  */
 
@@ -14,11 +16,12 @@ class NetiPhpExcel extends Plugin
 {
     /**
      * @param InstallContext $context
+     *
      * @throws \Exception
      */
     public function install(InstallContext $context)
     {
-        if (! is_readable(__DIR__ . DIRECTORY_SEPARATOR . 'vendor')) {
+        if (!is_readable(__DIR__ . DIRECTORY_SEPARATOR . 'vendor')) {
             throw new \Exception('Please run "composer install" before you install the plugin!');
         }
 

--- a/Service/PhpExcel.php
+++ b/Service/PhpExcel.php
@@ -1,7 +1,9 @@
 <?php
 /**
  * @copyright  Copyright (c) 2016, Net Inventors GmbH
+ *
  * @category   Shopware
+ *
  * @author     rubyc
  */
 
@@ -13,7 +15,7 @@ class PhpExcel
     const FORMAT_CSV   = 2;
 
     /**
-     * @var \PHPExcel|boolean
+     * @var \PHPExcel|bool
      */
     protected $phpExcel;
 
@@ -23,12 +25,12 @@ class PhpExcel
     public function getPhpExcel()
     {
         if (null === $this->phpExcel) {
-            if (! class_exists('PHPExcel')) {
+            if (!class_exists('PHPExcel')) {
                 require_once __DIR__ . '/../vendor/phpoffice/phpexcel/Classes/PHPExcel.php';
             }
 
             $this->phpExcel = new \PHPExcel();
-        } elseif (! $this->phpExcel instanceof \PHPExcel) {
+        } elseif (!$this->phpExcel instanceof \PHPExcel) {
             $this->phpExcel = false;
         }
 
@@ -40,18 +42,19 @@ class PhpExcel
      * The quality of the result depends on the contained values in the first row, it might nox be correct in any case.
      *
      * @param string $csvFile
+     *
      * @return string
      */
     public function detectDelimiter($csvFile)
     {
         $delimiters = [
-            ';' => 0,
-            ',' => 0,
+            ';'  => 0,
+            ','  => 0,
             "\t" => 0,
-            "|" => 0
+            '|'  => 0,
         ];
 
-        $handle = fopen($csvFile, "r");
+        $handle    = fopen($csvFile, 'r');
         $firstLine = fgets($handle);
         fclose($handle);
         foreach ($delimiters as $delimiter => &$count) {
@@ -62,13 +65,13 @@ class PhpExcel
     }
 
     /**
-     * @param array $data
-     * If $data contains an associative array, the keys will be set as headlines in the first row.
+     * @param array  $data
+     *                                     If $data contains an associative array, the keys will be set as headlines in the first row.
      * @param string $filename
-     * @param int $format
-     * self::FORMAT_CSV or self::FORMAT_EXCEL
+     * @param int    $format
+     *                                     self::FORMAT_CSV or self::FORMAT_EXCEL
      * @param string $delimiter
-     * @param bool $strictNullComparison
+     * @param bool   $strictNullComparison
      *
      * @throws \PHPExcel_Exception
      * @throws \PHPExcel_Reader_Exception
@@ -109,18 +112,20 @@ class PhpExcel
 
     /**
      * @param string $filename
-     * @return array
+     *
      * @throws \Exception
+     *
+     * @return array
      */
     public function getArrayFromFile($filename)
     {
-        if (! is_readable($filename)) {
+        if (!is_readable($filename)) {
             throw new \Exception('File does not exist or is not readable: ' . $filename);
         }
 
         $this->getPhpExcel();
         $inputFileType = \PHPExcel_IOFactory::identify($filename);
-        $objReader = \PHPExcel_IOFactory::createReader($inputFileType);
+        $objReader     = \PHPExcel_IOFactory::createReader($inputFileType);
 
         // detect and set delimiter
         if ('CSV' === $inputFileType) {
@@ -135,12 +140,12 @@ class PhpExcel
 
         $rows = [];
         foreach ($worksheet->getRowIterator() as $rowData) {
-            $row = [];
+            $row          = [];
             $cellIterator = $rowData->getCellIterator();
             $cellIterator->setIterateOnlyExistingCells(false); // Loop all cells, even if it is not set
             foreach ($cellIterator as $cell) {
                 /** @var \PHPExcel_Cell $cell */
-                if (! is_null($cell)) {
+                if (!is_null($cell)) {
                     $row[] = $cell->getValue();
                 }
             }
@@ -155,11 +160,12 @@ class PhpExcel
      * The keys will be taken from the first row of the $rows array.
      *
      * @param array $rows
+     *
      * @return array
      */
     public function createAssociativeArray($rows)
     {
-        $results = [];
+        $results  = [];
         $firstRow = true;
         foreach ($rows as $row) {
             if ($firstRow) {
@@ -183,7 +189,8 @@ class PhpExcel
 
     /**
      * @param array $arr
-     * @return boolean
+     *
+     * @return bool
      */
     private function isAssoc(array $arr)
     {
@@ -196,6 +203,7 @@ class PhpExcel
 
     /**
      * @param int $format
+     *
      * @return string
      */
     private function getExtension($format)
@@ -212,6 +220,7 @@ class PhpExcel
 
     /**
      * @param int $format
+     *
      * @return string
      */
     private function getWriterType($format)

--- a/Service/PhpExcel.php
+++ b/Service/PhpExcel.php
@@ -68,17 +68,27 @@ class PhpExcel
      * @param int $format
      * self::FORMAT_CSV or self::FORMAT_EXCEL
      * @param string $delimiter
+     * @param bool $strictNullComparison
+     *
+     * @throws \PHPExcel_Exception
+     * @throws \PHPExcel_Reader_Exception
+     * @throws \PHPExcel_Writer_Exception
      */
-    public function exportFunction($data, $filename, $format = self::FORMAT_CSV, $delimiter = ',')
-    {
+    public function exportFunction(
+        $data,
+        $filename,
+        $format = self::FORMAT_CSV,
+        $delimiter = ',',
+        $strictNullComparison = false
+    ) {
         $phpExcel = $this->getPhpExcel();
         $phpExcel->setActiveSheetIndex(0);
 
         if ($this->isAssoc(reset($data))) {
-            $phpExcel->getActiveSheet()->fromArray(array_keys(reset($data)), null, 'A1');
-            $phpExcel->getActiveSheet()->fromArray($data, null, 'A2');
+            $phpExcel->getActiveSheet()->fromArray(array_keys(reset($data)), null, 'A1', $strictNullComparison);
+            $phpExcel->getActiveSheet()->fromArray($data, null, 'A2', $strictNullComparison);
         } else {
-            $phpExcel->getActiveSheet()->fromArray($data, null, 'A1');
+            $phpExcel->getActiveSheet()->fromArray($data, null, 'A1', $strictNullComparison);
         }
 
         $filename = $filename . '.' . $this->getExtension($format);
@@ -91,7 +101,7 @@ class PhpExcel
             $objWriter->setDelimiter($delimiter);
         }
 
-        if (! (empty($objWriter)) && $objWriter instanceof \PHPExcel_Writer_IWriter) {
+        if (!(empty($objWriter)) && $objWriter instanceof \PHPExcel_Writer_IWriter) {
             $objWriter->save('php://output');
         }
         exit;


### PR DESCRIPTION
The Method `PHPExcel_Worksheet::fromArray()` takes a parameter `$strictNullComparison` which by default is `false` which has the effect that the cell data is not checked against the null value strictly, thus a value like `bool(false)` or `int(0)` will be treated like null, resulting in an empty cell.

Because this is very unfortunate in some situations, this PR adds a new parameter to `\NetiPhpExcel\Service\PhpExcel\exportFunction()` which can be used to set strict null comparison to `true`. 

For purposes of BC, the default value is `false`.