### PR TITLE
Composer installation support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,13 @@
 {
     "name": "net-inventors/neti-php-excel",
     "description": "Shopware Library-Plugin for phpExcel",
-    "type": "project",
+    "type": "shopware-plugin",
+    "extra": {
+        "installer-name": "NetiPhpExcel"
+    },
     "require": {
-        "phpoffice/phpexcel": "^1.8"
+        "phpoffice/phpexcel": "^1.8",
+        "composer/installers": "~1.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Hi. Here are changes that allow to install the plugin by composer.

If you accept it, it would be awesome if you also add the plugin to packagist. Then it will be possible to install it by one command: `composer require net-inventors/neti-php-excel`.

Thanks.